### PR TITLE
Added basic collision for walls and added small molecules to fill in gaps

### DIFF
--- a/script.js
+++ b/script.js
@@ -309,8 +309,16 @@ function addTemp() {
         }
     }
 
+
     function isCollidingWithWallOrPort(radius, x, y) {
-        return false;
+
+        if (x + radius < wallX || x - radius > wallX + wallWidth)
+            return false;
+        else if (port1Open == false && y + radius > 145 && y + radius < 220)
+            return false;
+        else if (port2Open == false && y + radius > 280 && y + radius < 335)
+            return false;
+        return true;
     }
 
     function isCollidingWithAT(x, y) {
@@ -350,7 +358,7 @@ class Molecule {
                 tempY = this.y + randomCo();
                 // If new location is outside canvas, loop
             } 
-            while (!isInCanvas(tempX, tempY) || isCollidingWithWallOrPort(radius,tempX, tempY));
+            while (!isInCanvas(tempX, tempY) || (isCollidingWithWallOrPort(radius,tempX, tempY)));
                 
             // Set particle coordinates to valid new location 
             this.x = tempX;

--- a/script.js
+++ b/script.js
@@ -249,6 +249,12 @@ function toggleMolecule1() {
         molecule1Visible = true;
         mole1BtnSpan.textContent = "Exclude";
     }
+
+    // If simulation has not started, update the new molecule start locations
+    if (!timerOn) {
+        particleStartLocations();
+    }
+
     updateDrawing();
 }
 
@@ -391,7 +397,7 @@ function particleStartLocations() {
                 molecules.push(new Molecule(moleculeEnum.smallMolecule, (25 + (c * 45)), (25 + (r * 50))));
 
                 // removes small molecule if near the big one
-                if ((2 <= c && c <= 4) && ((1 <= r && r <= 3) || (6 <= r && r <= 8))) {
+                if (molecule1Visible && (2 <= c && c <= 4) && ((1 <= r && r <= 3) || (6 <= r && r <= 8))) {
                     molecules.pop();
                 }
             }


### PR DESCRIPTION
Basic collision is there, though it does need to be tweaked a bit as the molecules clip into the wall. Collision does work for the closed ports as well.

The first commit is a small change to make sure to add extra small molecules when the large molecules are excluded. When the exclude button is pressed, the simulation also recreates the molecules array to update for the change visually with the new small molecules. 